### PR TITLE
feat: add support for decoding roomID from Space events

### DIFF
--- a/examples/adaptivecard.rs
+++ b/examples/adaptivecard.rs
@@ -53,13 +53,14 @@ async fn main() {
 
 async fn handle_adaptive_card(webex: &webex::Webex, event: &webex::Event) {
     // get attachmentactions
-    let actions: webex::types::AttachmentAction = match webex.get(&event.get_global_id()).await {
-        Ok(a) => a,
-        Err(e) => {
-            println!("Error: {}", e);
-            return;
-        }
-    };
+    let actions: webex::types::AttachmentAction =
+        match webex.get(&event.try_global_id().unwrap()).await {
+            Ok(a) => a,
+            Err(e) => {
+                println!("Error: {}", e);
+                return;
+            }
+        };
     let which_card = actions.inputs.as_ref().and_then(|inputs| inputs.get("id"));
     match which_card {
         None => println!(
@@ -109,7 +110,7 @@ async fn handle_adaptive_card_init(webex: &webex::Webex, actions: &webex::Attach
 
 async fn respond_to_message(webex: &webex::Webex, config: &Config, event: &webex::Event) {
     // Got a posted message
-    let message: webex::Message = match webex.get(&event.get_global_id()).await {
+    let message: webex::Message = match webex.get(&event.try_global_id().unwrap()).await {
         Ok(msg) => msg,
         Err(e) => {
             println!("Failed to get message: {}", e);

--- a/examples/auto-reply.rs
+++ b/examples/auto-reply.rs
@@ -37,7 +37,7 @@ async fn main() {
         // Dig out the useful bit
         if event.activity_type() == webex::ActivityType::Message(webex::MessageActivity::Posted) {
             // The event stream doesn't contain the message -- you have to go fetch it
-            if let Ok(msg) = webex.get::<webex::Message>(&event.get_global_id()).await {
+            if let Ok(msg) = webex.get::<webex::Message>(&event.try_global_id().unwrap()).await {
                 match &msg.person_email {
                     // Reply as long as it doesn't appear to be our own message
                     // In practice, this shouldn't happen since bots can't see messages

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -986,6 +986,7 @@ pub enum TextInputStyle {
 /// Height
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Height {
     Auto,
     Stretch,
@@ -1030,6 +1031,7 @@ pub enum Size {
 /// Image Size
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum ImageSize {
     Auto,
     Stretch,

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -120,6 +120,7 @@ pub enum CardElement {
     /// Containers group items together.
     Container {
         /// The card elements to render inside the Container.
+        #[serde(default)]
         items: Vec<CardElement>,
         /// An Action that will be invoked when the Container is tapped or selected.
         #[serde(rename = "selectAction", skip_serializing_if = "Option::is_none")]
@@ -827,6 +828,7 @@ impl CardElement {
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Column {
     /// The card elements to render inside the Column.
+    #[serde(default)]
     items: Vec<CardElement>,
     /// An Action that will be invoked when the Column is tapped or selected.
     #[serde(rename = "selectAction", skip_serializing_if = "Option::is_none")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -701,10 +701,10 @@ impl Event {
         let mut uuid = id;
         if uuid.as_bytes()[7] == b'2' {
             uuid.replace_range(7..8, "0");
+            Ok(uuid)
         } else {
-            panic!("Space created uuid {uuid} could not be not patched");
+            Err(crate::error::ErrorKind::Api("Space created event uuid could not be not patched").into())
         }
-        Ok(uuid)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -439,18 +439,31 @@ pub struct EventData {
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Activity {
+pub struct ActivityParent {
+    pub actor_id: String,
     pub id: String,
-    pub object_type: String,
-    pub url: Option<String>,
     pub published: String,
-    pub verb: String,
+    #[serde(rename = "type")]
+    pub parent_type: String,
+}
+
+#[allow(missing_docs)]
+#[skip_serializing_none]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Activity {
     pub actor: Actor,
-    pub object: Object,
-    pub target: Option<Target>,
     pub client_temp_id: Option<String>,
     pub encryption_key_url: Option<String>,
+    pub id: String,
+    pub object_type: String,
+    pub object: Object,
+    pub parent: Option<ActivityParent>,
+    pub published: String,
+    pub target: Option<Target>,
+    pub url: Option<String>,
     pub vector_counters: Option<VectorCounters>,
+    pub verb: String,
 }
 
 /// Get what activity an [`Activity`] represents.

--- a/src/types.rs
+++ b/src/types.rs
@@ -938,6 +938,7 @@ pub struct Object {
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MiscItems {
+    #[serde(default)]
     pub items: Vec<MiscItem>,
 }
 


### PR DESCRIPTION
Space events have a different way to report the target room id than message events. It also varies based on the Space event type, and the Create event requires patching of the UUID. §

This PR includes changes to make this all transparent in the `get_global_id`.

At the same time, it deprecates `get_global_id` in favour of `try_global_id` with error reporting.
